### PR TITLE
Update GAAPICommon to 1.39.1

### DIFF
--- a/src/BaseClients.Architecture/BaseClients.Architecture.csproj
+++ b/src/BaseClients.Architecture/BaseClients.Architecture.csproj
@@ -31,14 +31,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.5\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/BaseClients.Architecture/packages.config
+++ b/src/BaseClients.Architecture/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="NLog" version="4.7.5" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
 </packages>

--- a/src/BaseClients.Core/BaseClients.Core.csproj
+++ b/src/BaseClients.Core/BaseClients.Core.csproj
@@ -31,17 +31,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.5\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/BaseClients.Core/packages.config
+++ b/src/BaseClients.Core/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.5" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net47" />
 </packages>

--- a/tests/BaseClients.Test/BaseClients.Test.csproj
+++ b/tests/BaseClients.Test/BaseClients.Test.csproj
@@ -42,7 +42,7 @@
       <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.5\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.12.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.12.0\lib\net45\nunit.framework.dll</HintPath>

--- a/tests/BaseClients.Test/BaseClients.Test.csproj
+++ b/tests/BaseClients.Test/BaseClients.Test.csproj
@@ -35,11 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>

--- a/tests/BaseClients.Test/packages.config
+++ b/tests/BaseClients.Test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="NLog" version="4.7.5" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />
 </packages>

--- a/tests/BaseClients.Test/packages.config
+++ b/tests/BaseClients.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />


### PR DESCRIPTION
Update NLog to match Atlas II (4.7.9)