### PR TITLE
AI-1158 Explicitly close channel when heartbeat thread terminates

### DIFF
--- a/tests/BaseClients.Test/BaseClients.Test.csproj
+++ b/tests/BaseClients.Test/BaseClients.Test.csproj
@@ -35,11 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>

--- a/tests/BaseClients.Test/packages.config
+++ b/tests/BaseClients.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="NUnit" version="3.12.0" targetFramework="net47" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />


### PR DESCRIPTION
AI-1158 Closing the channel eliminates proliferation of unclosed TCP connections that eventually prevent opening a new client connection.